### PR TITLE
Add issue templates for beginner and advanced contributors

### DIFF
--- a/.github/ISSUE_TEMPLATE/advanced_issue.md
+++ b/.github/ISSUE_TEMPLATE/advanced_issue.md
@@ -1,0 +1,14 @@
+---
+name: Advanced Issue
+about: For complex or advanced contributions
+labels: advanced
+---
+
+## Problem Statement
+Describe the issue in detail.
+
+## Proposed Solution
+Explain your approach.
+
+## Impact
+How does this improve the project?

--- a/.github/ISSUE_TEMPLATE/beginner_issue.md
+++ b/.github/ISSUE_TEMPLATE/beginner_issue.md
@@ -1,0 +1,14 @@
+---
+name: Beginner Issue
+about: For first-time contributors
+labels: beginner
+---
+
+## Description
+Brief description of the issue.
+
+## Expected Outcome
+What should happen?
+
+## Additional Context
+Screenshots, logs, or references.

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,1 @@
+GitHub configuration folder


### PR DESCRIPTION
This PR adds structured GitHub issue templates to help contributors categorize issues based on skill level.

Closes #47
